### PR TITLE
Add ZamSync -- offline-first WAL sync engine in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Local-first software prioritizes local data storage and processing while enablin
 - [**Partykit**](https://github.com/partykit/partykit) - Multiplayer infrastructure with local-first patterns
 - [**Liveblocks**](https://github.com/liveblocks/liveblocks) - Real-time collaboration infrastructure
 - [**Evolu**](https://github.com/evoluhq/evolu) - Local-first platform with E2E encryption
+- [**ZamSync**](https://github.com/Etoile-Bleu/ZamSync) - Offline-first WAL sync engine in Rust for unreliable networks. HLC ordering, Version Vector deduplication, mTLS, ChaCha20-Poly1305 encryption at rest, static binary for ARM/IoT.
 
 ### P2P Protocols
 


### PR DESCRIPTION
## Add ZamSync

ZamSync is an offline-first WAL-based sync engine in Rust, built for environments where connectivity cannot be assumed. Designed for district clinics syncing patient records over 2G/EDGE (600ms latency, 30 kbps), it works correctly through hours of disconnection, mid-transfer cuts, and power loss.

**GitHub:** https://github.com/Etoile-Bleu/ZamSync
**Article:** https://dev.to/etoile_bleu/-i-built-a-sync-engine-for-clinics-that-run-on-2g-and-lose-power-mid-transfer-here-is-why-and-18od

Key properties:

- HLC (Hybrid Logical Clock) ordering + Version Vector deduplication, no duplicate events ever
- mTLS with hub-signed PKI, rogue nodes rejected at the TLS handshake
- WAL encryption at rest (ChaCha20-Poly1305, random nonce per record)
- Interrupted syncs resume exactly where they left off, no re-transmission
- Static binary under 5 MB, runs on Raspberry Pi 2 (ARMv7), 512 MB RAM minimum
- 117 tests, Toxiproxy-based e2e network simulation (2G profile)

Added to the Sync & Networking -- Sync Engines section.