### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Local-first software prioritizes local data storage and processing while enablin
 
 - [**Linear**](https://linear.app/) - Issue tracking with exceptional offline support (proprietary)
 - [**Claw Task Hub**](https://github.com/Catfish-75/claw-task-hub) - Local-first, SQLite-backed task hub for AI agents and agentic harness workflows
+- [**Tree Ring Memory**](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Local-first, SQLite/FTS-backed memory lifecycle CLI/TUI for AI agents with explicit recall, redaction, deletion, audit, consolidation, and JSON export.
 - [**Radicle**](https://github.com/radicle-dev/radicle-interface) - P2P code collaboration built on Git
 
 ### Communication


### PR DESCRIPTION
## Summary
- Add Tree Ring Memory to Applications / Development Tools.
- Position it as a local-first SQLite/FTS-backed memory lifecycle CLI/TUI for AI agents.

## Project
- Repository: https://github.com/TerminallyLazy/Tree-Ring-Memory

## Validation
- [x] Ran git diff --check
- [x] Verified the added GitHub URL returns HTTP 200