### PR TITLE
Add Vincent to Design & Creative applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Local-first software prioritizes local data storage and processing while enablin
 
 - [**Penpot**](https://github.com/penpot/penpot) - Open-source design and prototyping platform (local-first capable)
 - [**tldraw**](https://github.com/tldraw/tldraw) - Infinite canvas SDK with local-first multiplayer
+- [**Vincent**](https://github.com/iisacc-Justmoong/Vincent) - Private, local-first raster drawing and handwriting app for Windows; working files remain on the user's computer
 
 ### Development Tools
 


### PR DESCRIPTION
Adds Vincent to the **Applications → Design & Creative** section.

Vincent is a private, local-first raster drawing and handwriting application for Windows. Its documents and working files remain on the user's computer; the application requires no account and has no telemetry, advertising, or automatic updater. The complete source is available under AGPL-3.0.

The change follows the existing one-line application format, adds no new section, and the repository link returns HTTP 200.