### PR TITLE
Add Orkas to local-first applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Local-first software prioritizes local data storage and processing while enablin
 - [**Kuku**](https://kuku.mom) - Open-source local-first Markdown workspace with AI-assisted edits, backlinks, graph navigation, and optional encrypted sync
 - [**Logseq**](https://github.com/logseq/logseq) - Privacy-first, open-source knowledge base with bidirectional linking
 - [**Obsidian**](https://obsidian.md/) - Powerful knowledge base on top of local markdown files
+- [**Orkas**](https://github.com/Orkas-AI/Orkas) - Open-source desktop AI workforce where a Commander coordinates specialist agents through one chat while conversations, files, agent configuration, and model keys stay on-device
 - [**Notesnook**](https://github.com/streetwriters/notesnook) - Privacy-focused, end-to-end encrypted note-taking app
 - [**TidGi**](https://github.com/tiddly-gittly/TidGi-Desktop) - Personal knowledge base with Git backup
 - [**TiddlyWiki**](https://github.com/Jermolene/TiddlyWiki5) - Self-contained JavaScript wiki


### PR DESCRIPTION
## Summary

Add Orkas to Productivity & Knowledge Management as an open-source desktop AI workforce with local conversations, files, agent configuration, and model keys.

## Verification

- matched the existing list format
- linked the canonical source repository
- ran git diff --check