### PR TITLE
Add CuidaLocal to Health & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Local-first software prioritizes local data storage and processing while enablin
 
 ### Health & Fitness
 
+- [**CuidaLocal**](https://github.com/marcosmmjr2023/kit-organizacao-cuidados) - Offline PWA for family care coordination. Appointments, medications, contacts, and notes stay in browser local storage, with no account or backend
 - [**nobro.app**](https://nobro.app/) - Minimalist offline-first workout program tracker. State and editable program live in localStorage, no backend. PWA, 11 locales
 
 ## Frameworks & Platforms


### PR DESCRIPTION
Adds CuidaLocal to the existing Health & Fitness section.

CuidaLocal is an open-source, offline PWA for family care coordination. Its appointments, medications, contacts, and notes are stored in browser local storage; the app requires no account or backend. The linked repository contains the source and documentation for these properties.

This change adds one entry and does not alter any existing entries.